### PR TITLE
Completed instructions for bringing over Almost Amazon data

### DIFF
--- a/src/api/authorData.js
+++ b/src/api/authorData.js
@@ -1,7 +1,10 @@
 import { clientCredentials } from '../utils/client';
+// API CALLS FOR AUTHORS
 
 const endpoint = clientCredentials.databaseURL;
 
+// GET ALL AUTHORS
+// Same API call in Almost Amazon
 const getAuthors = (uid) =>
   new Promise((resolve, reject) => {
     fetch(`${endpoint}/authors.json?orderBy="uid"&equalTo="${uid}"`, {
@@ -21,10 +24,24 @@ const getAuthors = (uid) =>
       .catch(reject);
   });
 
-// FIXME: CREATE AUTHOR
-const createAuthor = () => {};
+// CREATE AN AUTHOR
+// API CALL TO CREATE AUTHOR (Transferred from Almost Amazon)
+const createAuthor = (payload) =>
+  new Promise((resolve, reject) => {
+    fetch(`${endpoint}/authors.json`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(data))
+      .catch(reject);
+  });
 
-// FIXME: GET SINGLE AUTHOR
+// GET A SINGLE AUTHOR
+// Same API call in Almost Amazon
 const getSingleAuthor = (firebaseKey) =>
   new Promise((resolve, reject) => {
     fetch(`${endpoint}/authors/${firebaseKey}.json`, {
@@ -38,7 +55,8 @@ const getSingleAuthor = (firebaseKey) =>
       .catch(reject);
   });
 
-// FIXME: DELETE AUTHOR
+// DELETE AN AUTHOR
+// Same API call in Almost Amazon
 const deleteSingleAuthor = (firebaseKey) =>
   new Promise((resolve, reject) => {
     fetch(`${endpoint}/authors/${firebaseKey}.json`, {
@@ -52,12 +70,39 @@ const deleteSingleAuthor = (firebaseKey) =>
       .catch(reject);
   });
 
-// FIXME: UPDATE AUTHOR
-const updateAuthor = () => {};
+// UPDATE AN AUTHOR
+// API CALL TO UPDATE AUTHOR (Transferred from Almost Amazon)
+const updateAuthor = (payload) =>
+  new Promise((resolve, reject) => {
+    fetch(`${endpoint}/authors/${payload.firebaseKey}.json`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(data))
+      .catch(reject);
+  });
 
-// TODO: GET A SINGLE AUTHOR'S BOOKS
-const getAuthorBooks = () => {};
+// GET A SINGLE AUTHOR'S BOOKS
+// API CALL TO GET A SINGLE AUTHOR'S BOOKS (Transferred from Almost Amazon)
+const getAuthorBooks = (firebaseKey) =>
+  new Promise((resolve, reject) => {
+    fetch(`${endpoint}/books.json?orderBy="author_id"&equalTo="${firebaseKey}"`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(Object.values(data)))
+      .catch(reject);
+  });
 
+// GET ALL AUTHORS WITH FAVORITE STATUS
+// Same API call in Almost Amazon
 const favoriteAuthors = (uid) =>
   new Promise((resolve, reject) => {
     fetch(`${endpoint}/authors.json?orderBy="uid"&equalTo="${uid}"`, {

--- a/src/api/bookData.js
+++ b/src/api/bookData.js
@@ -3,6 +3,8 @@ import { clientCredentials } from '../utils/client';
 
 const endpoint = clientCredentials.databaseURL;
 
+// GET ALL BOOKS
+// API CALL TO GET ALL BOOKS (Transferred from Almost Amazon. Slightly different considering if statement)
 const getBooks = (uid) =>
   new Promise((resolve, reject) => {
     fetch(`${endpoint}/books.json?orderBy="uid"&equalTo="${uid}"`, {
@@ -12,11 +14,18 @@ const getBooks = (uid) =>
       },
     })
       .then((response) => response.json())
-      .then((data) => resolve(Object.values(data)))
+      .then((data) => {
+        if (data) {
+          resolve(Object.values(data));
+        } else {
+          resolve([]);
+        }
+      })
       .catch(reject);
   });
 
-// TODO: DELETE BOOK
+// DELETE A BOOK
+// Same API call in Almost Amazon
 const deleteBook = (firebaseKey) =>
   new Promise((resolve, reject) => {
     fetch(`${endpoint}/books/${firebaseKey}.json`, {
@@ -30,7 +39,8 @@ const deleteBook = (firebaseKey) =>
       .catch(reject);
   });
 
-// TODO: GET SINGLE BOOK
+// GET A SINGLE BOOK
+// Same API call in Almost Amazon
 const getSingleBook = (firebaseKey) =>
   new Promise((resolve, reject) => {
     fetch(`${endpoint}/books/${firebaseKey}.json`, {
@@ -44,7 +54,8 @@ const getSingleBook = (firebaseKey) =>
       .catch(reject);
   });
 
-// TODO: CREATE BOOK
+// CREATE A BOOK
+// Same API call in Almost Amazon
 const createBook = (payload) =>
   new Promise((resolve, reject) => {
     fetch(`${endpoint}/books.json`, {
@@ -59,7 +70,8 @@ const createBook = (payload) =>
       .catch(reject);
   });
 
-// TODO: UPDATE BOOK
+// UPDATE A BOOK
+// Same API call in Almost Amazon
 const updateBook = (payload) =>
   new Promise((resolve, reject) => {
     fetch(`${endpoint}/books/${payload.firebaseKey}.json`, {
@@ -74,6 +86,8 @@ const updateBook = (payload) =>
       .catch(reject);
   });
 
+// GET ALL BOOKS BY AN AUTHOR
+// Did not have this API call in my Almost Amazon
 const getBooksByAuthor = (firebaseKey) =>
   new Promise((resolve, reject) => {
     fetch(`${endpoint}/books.json?orderBy="author_id"&equalTo="${firebaseKey}"`, {
@@ -87,6 +101,8 @@ const getBooksByAuthor = (firebaseKey) =>
       .catch(reject);
   });
 
+// GET ALL BOOKS ON SALE
+// Same API call in Almost Amazon
 const booksOnSale = (uid) =>
   new Promise((resolve, reject) => {
     fetch(`${endpoint}/books.json?orderBy="uid"&equalTo="${uid}"`, {
@@ -102,5 +118,21 @@ const booksOnSale = (uid) =>
       })
       .catch(reject);
   });
+
+// API CALL TO SEARCH FOR BOOKS (Transferred from Almost Amazon. This was a stretch goal)
+// const searchBook = (uid, keyword) => new Promise((resolve, reject) => {
+//   fetch(`${endpoint}/books.json?orderBy="uid"&equalTo="${uid}"`, {
+//     method: 'GET',
+//     headers: {
+//       'Content-Type': 'application/json',
+//     },
+//   })
+//     .then((response) => response.json())
+//     .then((data) => {
+//       const searched = Object.values(data).filter((item) => item.title.toLowerCase().includes(keyword.toLowerCase()));
+//       resolve(searched);
+//     })
+//     .catch(reject);
+// });
 
 export { getBooks, createBook, booksOnSale, deleteBook, getSingleBook, updateBook, getBooksByAuthor };

--- a/src/api/mergedData.js
+++ b/src/api/mergedData.js
@@ -1,6 +1,15 @@
 import { getAuthorBooks, getSingleAuthor, deleteSingleAuthor } from './authorData';
 import { getSingleBook, deleteBook } from './bookData';
 
+// Old Almost Amazon API CALL (book details)
+// const getBookDetails = (firebaseKey) => new Promise((resolve, reject) => {
+//   getSingleBook(firebaseKey).then((bookObj) => {
+//     getSingleAuthor(bookObj.author_id)
+//       .then((authorObj) => resolve({ ...bookObj, authorObj }));
+//   }).catch(reject);
+// });
+
+// New Simply Books API call (book details)
 const viewBookDetails = (bookFirebaseKey) =>
   new Promise((resolve, reject) => {
     getSingleBook(bookFirebaseKey)
@@ -12,6 +21,15 @@ const viewBookDetails = (bookFirebaseKey) =>
       .catch((error) => reject(error));
   });
 
+// Old Almost Amazon API CALL (author details)
+// const getAuthorDetails = (firebaseKey) => new Promise((resolve, reject) => {
+//   getSingleAuthor(firebaseKey).then((authorObj) => {
+//     getAuthorBooks(authorObj.firebaseKey)
+//       .then((bookObj) => resolve({ ...authorObj, bookObj }));
+//   }).catch(reject);
+// });
+
+// New Simply Books API call (author details)
 const viewAuthorDetails = (authorFirebaseKey) =>
   new Promise((resolve, reject) => {
     Promise.all([getSingleAuthor(authorFirebaseKey), getAuthorBooks(authorFirebaseKey)])
@@ -21,6 +39,18 @@ const viewAuthorDetails = (authorFirebaseKey) =>
       .catch((error) => reject(error));
   });
 
+// Old Almost Amazon API CALL (delete author books relationship)
+// const deleteAuthorBooksRelationship = (firebaseKey) => new Promise((resolve, reject) => {
+//   getAuthorBooks(firebaseKey).then((authorBooksArray) => {
+//     const deleteBookPromises = authorBooksArray.map((book) => deleteBook(book.firebaseKey));
+
+//     Promise.all(deleteBookPromises).then(() => {
+//       deleteSingleAuthor(firebaseKey).then(resolve);
+//     });
+//   }).catch(reject);
+// });
+
+// New Simply Books API call (delete author books relationship)
 const deleteAuthorBooks = (authorId) =>
   new Promise((resolve, reject) => {
     getAuthorBooks(authorId)


### PR DESCRIPTION
## Description
- Completed the instructions for Bring over the data (which can be found in [`GET_STARTED.md`](https://github.com/lndnbrr/simply-books-official/blob/main/project-docs/GET_STARTED.md#8-bring-over-the-data)). 
- Transferred over API calls from my previous project, Almost Amazon, that were necessary for this project. These changes are being placed with this request. 
## Related Issue
#33 

## Motivation and Context
This change was made so that a user has the capability to CRUD when these API calls are attached to event listeners (functions).

## How Can This Be Tested?
This is purely a placement of the API calls, so Devs can merely visualize the calls being placed into `src/api`
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)