### PR TITLE
Delete author books relationship

### DIFF
--- a/src/components/AuthorCard.js
+++ b/src/components/AuthorCard.js
@@ -6,12 +6,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Badge, Button, Card } from 'react-bootstrap';
 import Link from 'next/link';
-// import { deleteSingleAuthor } from '../api/authorData';
+
 import { deleteAuthorBooks } from '../api/mergedData';
 
 export default function AuthorCard({ authorObj, remainingAuthors }) {
   // Function that deletes the author.
-  // Uses deleteSingleAuthor API call to grab author with specific firebase key to delete.
+  // Uses deleteAuthorBooks API call to grab author's books with specific author id attachd to it, then runs a promise function to map all books by that author and deleting each book(by deleting each book's firebaseKey aka the obj itself), followed by deleting that author.
   // Then, calls anonymous function, which will update the DOM with the remaining authors (Anonymous function will begin working on src/app/authors/page.js, where it is passed the param of showAuthors(), also found on src/app/authors/page.js).
   const deleteAuthor = () => {
     deleteAuthorBooks(authorObj.firebaseKey).then(() => remainingAuthors());

--- a/src/components/AuthorCard.js
+++ b/src/components/AuthorCard.js
@@ -6,14 +6,15 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Badge, Button, Card } from 'react-bootstrap';
 import Link from 'next/link';
-import { deleteSingleAuthor } from '../api/authorData';
+// import { deleteSingleAuthor } from '../api/authorData';
+import { deleteAuthorBooks } from '../api/mergedData';
 
 export default function AuthorCard({ authorObj, remainingAuthors }) {
   // Function that deletes the author.
   // Uses deleteSingleAuthor API call to grab author with specific firebase key to delete.
   // Then, calls anonymous function, which will update the DOM with the remaining authors (Anonymous function will begin working on src/app/authors/page.js, where it is passed the param of showAuthors(), also found on src/app/authors/page.js).
   const deleteAuthor = () => {
-    deleteSingleAuthor(authorObj.firebaseKey).then(() => remainingAuthors());
+    deleteAuthorBooks(authorObj.firebaseKey).then(() => remainingAuthors());
   };
 
   return (


### PR DESCRIPTION
## Description
- When a user deletes an author, all of that author's books are deleted as well.
- The following changes are implemented with this request:
   - `src/components/AuthorCard.js`
      - `deleteSingleAuthor` was replaced with `deleteAuthorBooks` to ensure when deleting an author, that all books from that author are also deleted.
## Related Issue
#13 

## Motivation and Context
This follows the logic a book needs an author. And if the intended author is no longer in the directory, then the books should no longer be in that directory either.

## How Can This Be Tested?
1. If devs have access to this repo and have successfully set up the development environment, they can type `npm run dev` in the console to load up the link. 
2. They can then click the link to reach the application and do the following:
      - Log in (if applicable).
      - Navigate to the authors page through the nav bar.
      - Press the button to delete an author (says `delete`).
3. The author should disappear from the DOM
      - Navigate back to the books page.
4. All books from the recently deleted author should no longer be on the DOM.

## Screenshots (if appropriate):
### The following shows what it would look like if a user viewed an author's details.
https://github.com/user-attachments/assets/370b313f-f3eb-42d6-90fa-1602d3be9385

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)